### PR TITLE
feat: scaffold nuxt markdown template editor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Rename this file to .env and provide your OpenAI credentials
+OPENAI_API_KEY=sk-your-key-here

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+.nuxt
+.output
+.env
+.DS_Store
+*.log

--- a/README.md
+++ b/README.md
@@ -1,1 +1,80 @@
-# markdown-template
+# Markdown Template Editor
+
+A Nuxt 3 application that lets you build markdown templates with AI-assisted placeholder filling. Features a live markdown editor with syntax highlighting, real-time preview, placeholder guidance, and OpenAI-powered content generation.
+
+## Features
+- 📝 Markdown editor with CodeMirror syntax highlighting and live preview.
+- 🧩 Placeholder-aware templates using `{{placeholder_name}}` format.
+- 🤖 AI integration (OpenAI GPT-4o mini) to auto-fill placeholders based on user guidance.
+- 📄 Template library with sample project proposal and meeting notes templates.
+- 📥 Export tools to copy or download the generated markdown document.
+- ✅ Input validation, loading states, and error handling for a smooth experience.
+
+## Getting Started
+
+### 1. Install dependencies
+```bash
+pnpm install
+# or
+yarn install
+# or
+npm install
+```
+
+### 2. Configure environment
+Create a `.env` file in the project root:
+```
+OPENAI_API_KEY=sk-...
+```
+
+### 3. Run the development server
+```bash
+npm run dev
+```
+
+Visit [http://localhost:3000/editor](http://localhost:3000/editor) to access the editor.
+
+## Project Structure
+```
+.
+├── app.vue
+├── assets/
+│   └── styles/main.css
+├── components/
+│   ├── GeneratedPreview.vue
+│   ├── MarkdownEditor.vue
+│   └── TemplateSelector.vue
+├── composables/
+│   └── useAI.ts
+├── pages/
+│   ├── editor.vue
+│   ├── index.vue
+│   ├── preview.vue
+│   └── templates.vue
+├── plugins/
+│   └── codemirror.client.ts
+├── server/
+│   └── api/generate.post.ts
+├── stores/
+│   └── useTemplateStore.ts
+├── types/
+│   └── ai.ts
+├── nuxt.config.ts
+├── package.json
+├── tailwind.config.js
+└── README.md
+```
+
+## AI Generation Flow
+1. Select a template or craft your own markdown in the editor.
+2. Provide guidance for each detected placeholder in the sidebar form.
+3. Click **Generate Document** to send the template, placeholders, and guidance to the `/api/generate` endpoint.
+4. The API calls OpenAI and returns filled content for each placeholder.
+5. The live preview and preview page render the completed markdown document in real time.
+
+## Notes
+- The OpenAI API call uses the `gpt-4o-mini` model; update the model name in `server/api/generate.post.ts` if needed.
+- Ensure billing is enabled on your OpenAI account to avoid API errors.
+- Tailwind CSS powers the UI and includes the typography plugin for pleasant markdown rendering.
+
+Enjoy crafting polished markdown documents with AI assistance! 🚀

--- a/app.vue
+++ b/app.vue
@@ -1,0 +1,20 @@
+<template>
+  <div class="min-h-screen flex flex-col">
+    <header class="bg-white shadow-sm">
+      <nav class="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
+        <NuxtLink to="/editor" class="text-xl font-semibold text-primary">Markdown Template Editor</NuxtLink>
+        <div class="space-x-4 text-sm font-medium">
+          <NuxtLink class="hover:text-primary transition" to="/templates">Templates</NuxtLink>
+          <NuxtLink class="hover:text-primary transition" to="/editor">Editor</NuxtLink>
+          <NuxtLink class="hover:text-primary transition" to="/preview">Preview</NuxtLink>
+        </div>
+      </nav>
+    </header>
+    <main class="flex-1">
+      <NuxtPage />
+    </main>
+    <footer class="bg-slate-900 text-slate-100 text-center py-6 text-sm">
+      Built with ❤️ using Nuxt 3 + OpenAI
+    </footer>
+  </div>
+</template>

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -1,0 +1,27 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-slate-100 text-slate-900;
+}
+
+.markdown-preview h1 {
+  @apply text-3xl font-bold mt-6 mb-3;
+}
+
+.markdown-preview h2 {
+  @apply text-2xl font-semibold mt-5 mb-2;
+}
+
+.markdown-preview p {
+  @apply mb-3 leading-relaxed;
+}
+
+.markdown-preview pre {
+  @apply bg-slate-900 text-slate-100 p-4 rounded-lg overflow-x-auto;
+}
+
+.markdown-preview code {
+  @apply bg-slate-200 text-slate-800 px-1 rounded;
+}

--- a/components/GeneratedPreview.vue
+++ b/components/GeneratedPreview.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import { computed, defineProps } from 'vue'
+import { marked } from 'marked'
+
+const props = defineProps<{
+  template: string
+  values: Record<string, string>
+}>()
+
+const compiledMarkdown = computed(() => {
+  let result = props.template
+  for (const [key, value] of Object.entries(props.values)) {
+    const pattern = new RegExp(`{{\\s*${key}\\s*}}`, 'gi')
+    result = result.replace(pattern, value ?? '')
+  }
+  return marked.parse(result)
+})
+</script>
+
+<template>
+  <div class="bg-white border border-slate-200 rounded-lg shadow-sm p-6">
+    <h2 class="text-xl font-semibold mb-4 text-slate-800">Live Preview</h2>
+    <div class="markdown-preview prose prose-slate max-w-none" v-html="compiledMarkdown" />
+  </div>
+</template>

--- a/components/MarkdownEditor.vue
+++ b/components/MarkdownEditor.vue
@@ -1,0 +1,77 @@
+<script setup lang="ts">
+import { shallowRef, watch, defineProps, defineEmits, ref } from 'vue'
+import type { EditorView } from '@codemirror/view'
+
+const props = defineProps<{
+  modelValue: string
+  label?: string
+}>()
+
+const emit = defineEmits<{
+  (event: 'update:modelValue', value: string): void
+}>()
+
+const editorValue = ref(props.modelValue)
+const view = shallowRef<EditorView | null>(null)
+
+watch(
+  () => props.modelValue,
+  (value) => {
+    if (value !== editorValue.value) {
+      editorValue.value = value
+      view.value?.dispatch({
+        changes: {
+          from: 0,
+          to: view.value.state.doc.length,
+          insert: value
+        }
+      })
+    }
+  }
+)
+
+watch(editorValue, (value) => {
+  emit('update:modelValue', value)
+})
+
+const extensions = [
+  (await import('@codemirror/lang-markdown')).markdown()
+]
+
+const handleReady = (payload: { view: EditorView }) => {
+  view.value = payload.view
+}
+</script>
+
+<template>
+  <div>
+    <label v-if="label" class="block text-sm font-semibold text-slate-700 mb-2">{{ label }}</label>
+    <ClientOnly fallback="Loading editor...">
+      <VueCodemirror
+        v-model="editorValue"
+        placeholder="Write or edit your markdown template here..."
+        :extensions="extensions"
+        :style="{ height: '480px' }"
+        class="border border-slate-300 rounded-lg overflow-hidden"
+        @ready="handleReady"
+      />
+      <template #fallback>
+        <textarea
+          v-model="editorValue"
+          class="w-full h-96 border border-slate-300 rounded-lg p-4 font-mono text-sm"
+        />
+      </template>
+    </ClientOnly>
+  </div>
+</template>
+
+<style scoped>
+:deep(.cm-editor) {
+  font-family: 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  background-color: white;
+}
+
+:deep(.cm-content) {
+  min-height: 480px;
+}
+</style>

--- a/components/TemplateSelector.vue
+++ b/components/TemplateSelector.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import { storeToRefs } from 'pinia'
+import { useTemplateStore } from '~/stores/useTemplateStore'
+
+const store = useTemplateStore()
+const { templates, selectedTemplateId } = storeToRefs(store)
+
+const handleChange = (event: Event) => {
+  const value = (event.target as HTMLSelectElement).value
+  store.selectTemplate(value)
+}
+</script>
+
+<template>
+  <div class="bg-white rounded-lg border border-slate-200 p-4 shadow-sm">
+    <div class="flex items-center justify-between mb-3">
+      <h2 class="text-lg font-semibold text-slate-800">Choose a template</h2>
+      <span class="text-xs text-slate-500">{{ templates.length }} available</span>
+    </div>
+    <select
+      :value="selectedTemplateId"
+      class="w-full border border-slate-300 rounded-md px-3 py-2 focus:ring-2 focus:ring-primary focus:outline-none"
+      @change="handleChange"
+    >
+      <option v-for="template in templates" :key="template.id" :value="template.id">
+        {{ template.name }}
+      </option>
+    </select>
+    <p v-if="store.selectedTemplate" class="text-sm text-slate-500 mt-2">
+      {{ store.selectedTemplate?.description }}
+    </p>
+  </div>
+</template>

--- a/composables/useAI.ts
+++ b/composables/useAI.ts
@@ -1,0 +1,20 @@
+import type { PlaceholderRequestPayload, PlaceholderResponse } from '~/types/ai'
+
+export const useAI = () => {
+  const generatePlaceholders = async (payload: PlaceholderRequestPayload) => {
+    try {
+      const response = await $fetch<PlaceholderResponse>('/api/generate', {
+        method: 'POST',
+        body: payload
+      })
+      return response
+    } catch (error) {
+      console.error('AI generation error', error)
+      throw error
+    }
+  }
+
+  return {
+    generatePlaceholders
+  }
+}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,0 +1,29 @@
+import { defineNuxtConfig } from 'nuxt/config'
+
+export default defineNuxtConfig({
+  modules: [
+    '@nuxtjs/tailwindcss',
+    '@pinia/nuxt'
+  ],
+  runtimeConfig: {
+    openaiApiKey: process.env.OPENAI_API_KEY,
+    public: {
+      appName: 'Markdown Template Editor'
+    }
+  },
+  css: [
+    '@/assets/styles/main.css'
+  ],
+  typescript: {
+    strict: true,
+    typeCheck: false
+  },
+  app: {
+    head: {
+      title: 'Markdown Template Editor',
+      meta: [
+        { name: 'description', content: 'AI-powered markdown template editor with live preview.' }
+      ]
+    }
+  }
+})

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "markdown-template-editor",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "nuxt dev",
+    "build": "nuxt build",
+    "start": "nuxt start",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "@codemirror/lang-markdown": "^6.2.3",
+    "@pinia/nuxt": "^0.5.1",
+    "@uiw/vue-codemirror": "^4.24.6",
+    "nuxt": "^3.10.3",
+    "openai": "^4.38.2",
+    "pinia": "^2.1.7",
+    "marked": "^9.1.5",
+    "@codemirror/view": "^6.24.1"
+  },
+  "devDependencies": {
+    "@nuxtjs/eslint-config-typescript": "^12.0.0",
+    "@nuxtjs/tailwindcss": "^6.12.0",
+    "eslint": "^8.57.0",
+    "eslint-plugin-vue": "^9.20.1",
+    "tailwindcss": "^3.4.3",
+    "typescript": "^5.4.5",
+    "@tailwindcss/typography": "^0.5.10"
+  }
+}

--- a/pages/editor.vue
+++ b/pages/editor.vue
@@ -1,0 +1,143 @@
+<script setup lang="ts">
+import { computed, reactive } from 'vue'
+import { storeToRefs } from 'pinia'
+import MarkdownEditor from '~/components/MarkdownEditor.vue'
+import TemplateSelector from '~/components/TemplateSelector.vue'
+import GeneratedPreview from '~/components/GeneratedPreview.vue'
+import { useTemplateStore } from '~/stores/useTemplateStore'
+import { useAI } from '~/composables/useAI'
+
+const store = useTemplateStore()
+const { editorContent, placeholders, mergedValues, isGenerating, errorMessage } = storeToRefs(store)
+const { generatePlaceholders } = useAI()
+
+const formErrors = reactive<Record<string, string>>({})
+
+const hasErrors = computed(() => Object.values(formErrors).some(Boolean))
+
+const finalMarkdown = computed(() => {
+  let filled = editorContent.value
+  for (const [key, value] of Object.entries(mergedValues.value)) {
+    const pattern = new RegExp(`{{\\s*${key}\\s*}}`, 'gi')
+    filled = filled.replace(pattern, value ?? '')
+  }
+  return filled
+})
+
+const validateInputs = () => {
+  Object.keys(formErrors).forEach((key) => delete formErrors[key])
+  placeholders.value.forEach((name) => {
+    if (!store.placeholderValues[name]?.trim()) {
+      formErrors[name] = 'Please provide guidance for this placeholder before generating.'
+    }
+  })
+}
+
+const handleGenerate = async () => {
+  validateInputs()
+  if (hasErrors.value) {
+    return
+  }
+
+  try {
+    store.setIsGenerating(true)
+    store.setError(null)
+    const response = await generatePlaceholders({
+      template: editorContent.value,
+      placeholders: placeholders.value,
+      context: store.placeholderValues
+    })
+    store.setGeneratedValues(response.values)
+  } catch (error: any) {
+    const message = error?.data?.message || error?.message || 'Failed to generate content. Please try again.'
+    store.setError(message)
+  } finally {
+    store.setIsGenerating(false)
+  }
+}
+
+const copyToClipboard = async () => {
+  try {
+    await navigator.clipboard.writeText(finalMarkdown.value)
+  } catch (error) {
+    console.error('Clipboard copy failed', error)
+  }
+}
+
+const downloadMarkdown = () => {
+  const blob = new Blob([finalMarkdown.value], { type: 'text/markdown' })
+  const link = document.createElement('a')
+  link.href = URL.createObjectURL(blob)
+  link.download = 'generated-document.md'
+  link.click()
+  URL.revokeObjectURL(link.href)
+}
+</script>
+
+<template>
+  <section class="max-w-6xl mx-auto px-6 py-10 space-y-8">
+    <div class="flex flex-col gap-6 lg:flex-row">
+      <div class="lg:w-1/3 space-y-6">
+        <TemplateSelector />
+        <div class="bg-white border border-slate-200 rounded-lg shadow-sm p-4">
+          <h2 class="text-lg font-semibold text-slate-800 mb-2">Placeholder Guidance</h2>
+          <p class="text-sm text-slate-500 mb-4">
+            Provide context for each placeholder. The AI will use these hints to craft complete sections.
+          </p>
+          <div v-if="placeholders.length === 0" class="text-sm text-slate-400">
+            No placeholders detected. Add {{'{{placeholder}}'}} tokens to your template.
+          </div>
+          <div v-for="name in placeholders" :key="name" class="mb-4">
+            <label class="block text-sm font-medium text-slate-700 mb-1">{{ name }}</label>
+            <textarea
+              :value="store.placeholderValues[name] ?? ''"
+              class="w-full border border-slate-300 rounded-md px-3 py-2 text-sm focus:ring-2 focus:ring-primary focus:outline-none"
+              rows="3"
+              placeholder="Describe what should go into {{ name }}"
+              @input="store.updatePlaceholderValue(name, ($event.target as HTMLTextAreaElement).value)"
+            />
+            <p v-if="formErrors[name]" class="text-xs text-red-500 mt-1">{{ formErrors[name] }}</p>
+            <p v-else-if="store.generatedValues[name]" class="text-xs text-emerald-600 mt-1">
+              Generated value available.
+            </p>
+          </div>
+        </div>
+      </div>
+      <div class="lg:w-2/3 space-y-6">
+        <MarkdownEditor v-model="store.editorContent" label="Markdown Template" />
+        <div class="flex flex-wrap gap-3">
+          <button
+            class="px-5 py-2 bg-primary text-white rounded-md shadow hover:bg-primary/90 disabled:opacity-60 disabled:cursor-not-allowed"
+            :disabled="isGenerating"
+            @click="handleGenerate"
+          >
+            <span v-if="isGenerating" class="flex items-center gap-2">
+              <svg class="animate-spin h-4 w-4 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
+              </svg>
+              Generating...
+            </span>
+            <span v-else>Generate Document</span>
+          </button>
+          <button
+            class="px-5 py-2 border border-slate-300 text-slate-700 rounded-md hover:bg-slate-100"
+            type="button"
+            @click="copyToClipboard"
+          >
+            Copy Markdown
+          </button>
+          <button
+            class="px-5 py-2 border border-slate-300 text-slate-700 rounded-md hover:bg-slate-100"
+            type="button"
+            @click="downloadMarkdown"
+          >
+            Download .md
+          </button>
+        </div>
+        <p v-if="errorMessage" class="text-sm text-red-500">{{ errorMessage }}</p>
+        <GeneratedPreview :template="editorContent" :values="mergedValues" />
+      </div>
+    </div>
+  </section>
+</template>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+definePageMeta({
+  redirect: '/editor'
+})
+</script>
+
+<template>
+  <div class="p-12 text-center text-slate-500">
+    Redirecting to editor...
+  </div>
+</template>

--- a/pages/preview.vue
+++ b/pages/preview.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { storeToRefs } from 'pinia'
+import GeneratedPreview from '~/components/GeneratedPreview.vue'
+import { useTemplateStore } from '~/stores/useTemplateStore'
+
+const store = useTemplateStore()
+const { editorContent, mergedValues } = storeToRefs(store)
+
+const placeholderCount = computed(() => Object.keys(mergedValues.value).length)
+</script>
+
+<template>
+  <section class="max-w-5xl mx-auto px-6 py-12 space-y-6">
+    <header class="flex items-center justify-between">
+      <div>
+        <h1 class="text-3xl font-bold text-slate-900">Generated Preview</h1>
+        <p class="text-slate-500 mt-1">Review the filled markdown content before exporting.</p>
+      </div>
+      <NuxtLink to="/editor" class="px-4 py-2 bg-primary text-white rounded-md shadow hover:bg-primary/90">Back to Editor</NuxtLink>
+    </header>
+    <div class="bg-white border border-slate-200 rounded-lg shadow-sm p-4">
+      <p class="text-sm text-slate-500">Placeholders populated: <strong>{{ placeholderCount }}</strong></p>
+    </div>
+    <GeneratedPreview :template="editorContent" :values="mergedValues" />
+  </section>
+</template>

--- a/pages/templates.vue
+++ b/pages/templates.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import { storeToRefs } from 'pinia'
+import { useTemplateStore } from '~/stores/useTemplateStore'
+
+const store = useTemplateStore()
+const { templates, selectedTemplateId } = storeToRefs(store)
+
+const goToEditor = (id: string) => {
+  store.selectTemplate(id)
+  navigateTo('/editor')
+}
+</script>
+
+<template>
+  <section class="max-w-6xl mx-auto px-6 py-10">
+    <div class="flex items-center justify-between mb-8">
+      <div>
+        <h1 class="text-3xl font-bold text-slate-900">Template Library</h1>
+        <p class="text-slate-500 mt-1">Select a template to load it into the editor.</p>
+      </div>
+      <NuxtLink to="/editor" class="px-4 py-2 bg-primary text-white rounded-md shadow hover:bg-primary/90">
+        Go to Editor
+      </NuxtLink>
+    </div>
+    <div class="grid gap-6 md:grid-cols-2">
+      <article
+        v-for="template in templates"
+        :key="template.id"
+        class="bg-white border border-slate-200 rounded-xl shadow-sm p-6 flex flex-col justify-between"
+      >
+        <div>
+          <div class="flex items-start justify-between">
+            <h2 class="text-2xl font-semibold text-slate-800">{{ template.name }}</h2>
+            <span
+              class="text-xs uppercase font-semibold tracking-wider"
+              :class="template.id === selectedTemplateId ? 'text-primary' : 'text-slate-400'"
+            >
+              {{ template.id === selectedTemplateId ? 'Selected' : 'Available' }}
+            </span>
+          </div>
+          <p class="text-slate-500 mt-3">{{ template.description }}</p>
+          <pre class="bg-slate-900 text-slate-100 text-xs p-4 rounded-lg mt-4 overflow-x-auto">
+{{ template.content }}
+          </pre>
+        </div>
+        <button
+          class="mt-6 px-4 py-2 border border-primary text-primary rounded-md hover:bg-primary hover:text-white transition"
+          @click="goToEditor(template.id)"
+        >
+          Use this template
+        </button>
+      </article>
+    </div>
+  </section>
+</template>

--- a/plugins/codemirror.client.ts
+++ b/plugins/codemirror.client.ts
@@ -1,0 +1,7 @@
+import '@uiw/vue-codemirror/dist/style.css'
+import { defineNuxtPlugin } from '#app'
+import VueCodemirror from '@uiw/vue-codemirror'
+
+export default defineNuxtPlugin((nuxtApp) => {
+  nuxtApp.vueApp.use(VueCodemirror)
+})

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+}

--- a/server/api/generate.post.ts
+++ b/server/api/generate.post.ts
@@ -1,0 +1,99 @@
+import OpenAI from 'openai'
+import type { PlaceholderRequestPayload, PlaceholderResponse } from '~/types/ai'
+
+const buildPrompt = (payload: PlaceholderRequestPayload) => {
+  const placeholderList = payload.placeholders.map((name) => `- ${name}`).join('\n')
+  const contextEntries = Object.entries(payload.context)
+    .map(([key, value]) => `- ${key}: ${value}`)
+    .join('\n') || 'No additional context provided.'
+
+  return `You are a writing assistant that completes markdown templates.
+Template markdown:
+"""
+${payload.template}
+"""
+
+The template includes placeholders in double curly braces like {{placeholder}}.
+Fill each placeholder with concise, professional markdown content. Respect markdown syntax and keep tables intact.
+
+List of placeholders:
+${placeholderList}
+
+User provided context for placeholders:
+${contextEntries}
+
+Respond ONLY with a valid JSON object with the following shape:
+{
+  "values": {
+    "placeholder_name": "filled markdown content"
+  }
+}
+Ensure every placeholder listed is present in the JSON.`
+}
+
+export default defineEventHandler(async (event): Promise<PlaceholderResponse> => {
+  const body = await readBody<PlaceholderRequestPayload>(event)
+  body.context = body.context ?? {}
+
+  if (!body || !Array.isArray(body.placeholders) || body.placeholders.length === 0) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Invalid payload: No placeholders supplied.'
+    })
+  }
+
+  const config = useRuntimeConfig()
+  if (!config.openaiApiKey) {
+    throw createError({
+      statusCode: 500,
+      statusMessage: 'Missing OpenAI API key. Set OPENAI_API_KEY in your environment.'
+    })
+  }
+
+  const openai = new OpenAI({ apiKey: config.openaiApiKey })
+
+  const completion = await openai.chat.completions.create({
+    model: 'gpt-4o-mini',
+    temperature: 0.7,
+    messages: [
+      {
+        role: 'system',
+        content: 'You are a meticulous assistant that fills in markdown templates using user hints. Always respond with valid JSON.'
+      },
+      {
+        role: 'user',
+        content: buildPrompt(body)
+      }
+    ],
+    response_format: { type: 'json_object' }
+  })
+
+  const raw = completion.choices[0]?.message?.content
+  if (!raw) {
+    throw createError({
+      statusCode: 502,
+      statusMessage: 'OpenAI did not return a response.'
+    })
+  }
+
+  let parsed: PlaceholderResponse
+  try {
+    parsed = JSON.parse(raw) as PlaceholderResponse
+    parsed.values = parsed.values ?? {}
+  } catch (error) {
+    console.error('Failed to parse OpenAI response', error, raw)
+    throw createError({
+      statusCode: 502,
+      statusMessage: 'Failed to parse AI response.'
+    })
+  }
+
+  const missing = body.placeholders.filter((name) => !(name in parsed.values))
+  if (missing.length > 0) {
+    for (const name of missing) {
+      parsed.values[name] = ''
+    }
+  }
+
+  return parsed
+})

--- a/stores/useTemplateStore.ts
+++ b/stores/useTemplateStore.ts
@@ -1,0 +1,121 @@
+import { defineStore } from 'pinia'
+
+type PlaceholderMap = Record<string, string>
+
+type Template = {
+  id: string
+  name: string
+  description: string
+  content: string
+}
+
+const defaultTemplates: Template[] = [
+  {
+    id: 'project-proposal',
+    name: 'Project Proposal',
+    description: 'A concise proposal structure for new initiatives.',
+    content: `# Project Proposal: {{project_title}}
+
+## Executive Summary
+{{executive_summary}}
+
+## Objectives
+- {{objective_one}}
+- {{objective_two}}
+- {{objective_three}}
+
+## Timeline
+| Milestone | Date | Owner |
+| --- | --- | --- |
+| {{milestone_one}} | {{milestone_one_date}} | {{milestone_one_owner}} |
+| {{milestone_two}} | {{milestone_two_date}} | {{milestone_two_owner}} |
+
+## Budget Overview
+{{budget_overview}}
+
+## Call To Action
+{{call_to_action}}
+`
+  },
+  {
+    id: 'meeting-notes',
+    name: 'Meeting Notes',
+    description: 'Structured meeting note template with decisions and action items.',
+    content: `# Meeting Notes: {{meeting_topic}}
+
+**Date:** {{meeting_date}}
+**Facilitator:** {{facilitator}}
+
+## Agenda Highlights
+{{agenda}}
+
+## Key Decisions
+{{decisions}}
+
+## Action Items
+1. {{action_item_one}}
+2. {{action_item_two}}
+3. {{action_item_three}}
+`
+  }
+]
+
+export const useTemplateStore = defineStore('template', {
+  state: () => ({
+    templates: defaultTemplates,
+    selectedTemplateId: defaultTemplates[0]?.id ?? '',
+    editorContent: defaultTemplates[0]?.content ?? '',
+    placeholderValues: {} as PlaceholderMap,
+    generatedValues: {} as PlaceholderMap,
+    isGenerating: false,
+    errorMessage: '' as string | null
+  }),
+  getters: {
+    selectedTemplate(state): Template | undefined {
+      return state.templates.find((template) => template.id === state.selectedTemplateId)
+    },
+    placeholders(state): string[] {
+      const pattern = /{{(.*?)}}/g
+      const unique = new Set<string>()
+      let match
+      while ((match = pattern.exec(state.editorContent)) !== null) {
+        unique.add(match[1].trim())
+      }
+      return Array.from(unique)
+    },
+    mergedValues(state): PlaceholderMap {
+      return Object.fromEntries(
+        this.placeholders.map((name) => [name, state.generatedValues[name] ?? state.placeholderValues[name] ?? ''])
+      )
+    }
+  },
+  actions: {
+    setTemplateContent(content: string) {
+      this.editorContent = content
+    },
+    selectTemplate(id: string) {
+      const found = this.templates.find((template) => template.id === id)
+      if (found) {
+        this.selectedTemplateId = found.id
+        this.editorContent = found.content
+        this.placeholderValues = {}
+        this.generatedValues = {}
+      }
+    },
+    updatePlaceholderValue(name: string, value: string) {
+      this.placeholderValues = {
+        ...this.placeholderValues,
+        [name]: value
+      }
+    },
+    setGeneratedValues(values: PlaceholderMap) {
+      this.generatedValues = values
+    },
+    setIsGenerating(value: boolean) {
+      this.isGenerating = value
+    },
+    setError(message: string | null) {
+      this.errorMessage = message ?? ''
+    }
+  }
+})

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,19 @@
+module.exports = {
+  content: [
+    './components/**/*.{vue,js,ts}',
+    './layouts/**/*.vue',
+    './pages/**/*.vue',
+    './composables/**/*.{js,ts}',
+    './plugins/**/*.{js,ts}',
+    './app.vue'
+  ],
+  theme: {
+    extend: {
+      colors: {
+        primary: '#2563eb',
+        accent: '#22d3ee'
+      }
+    }
+  },
+  plugins: [require('@tailwindcss/typography')]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./.nuxt/tsconfig.json"
+}

--- a/types/ai.ts
+++ b/types/ai.ts
@@ -1,0 +1,9 @@
+export type PlaceholderRequestPayload = {
+  template: string
+  placeholders: string[]
+  context: Record<string, string>
+}
+
+export type PlaceholderResponse = {
+  values: Record<string, string>
+}


### PR DESCRIPTION
## Summary
- scaffold a Nuxt 3 application for AI-assisted markdown template editing
- build editor, template selector, preview components, and Pinia store for placeholder guidance
- add OpenAI-powered API endpoint, composable, and Tailwind styling with sample templates and exports

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9915998448322996564d63591d8da